### PR TITLE
Håndterer nå flere forfattere og setter dem sammen med ',' og 'og'

### DIFF
--- a/_extensions/nifu_pub/typst-show.typ
+++ b/_extensions/nifu_pub/typst-show.typ
@@ -5,8 +5,9 @@
   authors: (
     $for(by-author)$
     (
-      name: "$it.name.literal$"
-    ) $endfor$
+      "$it.name.literal$"
+    )$sep$,
+    $endfor$
   ),
   report_no: "$report_no$",
   project_no: "$project_no$",

--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -49,6 +49,10 @@
         #image("nifu_rapp_bg.png")]
       }
     ))
+    
+  let concatenatedAuthors = if type(authors) != "string" [
+     #authors.join(", ", last: " og ")
+     ] else [#authors]
 
   set heading(numbering: "1.1.1    ")
 
@@ -155,7 +159,7 @@
         #text(
           size: 12.5pt,
           font: "Calibri"  
-        )[#authors.name]]]
+        )[#concatenatedAuthors]]]
   }
 
   pagebreak()
@@ -195,7 +199,7 @@
         #text(
           size: 12.5pt,
           font: "Calibri"
-        )[#authors.name]]]
+        )[#concatenatedAuthors]]]
 
     line(
     stroke: 1.5pt + rgb("#C84957"),


### PR DESCRIPTION
Malen skal nå håndtere følgende situasjoner:
1. ingen author:-felt i det hele tatt
2. en 
````qmd 
---
author: Karl Henrikstrom
---
````
4. flere author:
````qmd
---
author:
 - Henrik Karlstrom
 - Stephan Daus
 - Bjørnstjerne Bjørnsson
---
`````

Ulempen er at jeg måtte fjerne "name:"-taggen. Så usikker på om den vil fungere for mer avanserte author-spesifikasjoner med for eksempel affiliation, osv. Aller helst bør den kunne trekke ut name-field og ignorere alt annet. Men tenkte at det er viktigere nå å kunne håndtere flere forfattere.

Closes #1 