### PR TITLE
References as optional

### DIFF
--- a/_extensions/nifu_pub/typst-show.typ
+++ b/_extensions/nifu_pub/typst-show.typ
@@ -5,8 +5,9 @@
   authors: (
     $for(by-author)$
     (
-      name: "$it.name.literal$"
-    ) $endfor$
+      "$it.name.literal$"
+    )$sep$,
+    $endfor$
   ),
   report_no: "$report_no$",
   project_no: "$project_no$",

--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -299,7 +299,7 @@
   
   doc
 
-  if references != none {
+  if references != "" {
     set par(first-line-indent: 0pt)
     set block(
       inset: (left: 1.5em)

--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -49,6 +49,10 @@
         #image("nifu_rapp_bg.png")]
       }
     ))
+    
+  let concatenatedAuthors = if type(authors) != "string" [
+     #authors.join(", ", last: " og ")
+     ] else [#authors]
 
   set heading(numbering: "1.1.1    ")
 
@@ -155,7 +159,7 @@
         #text(
           size: 12.5pt,
           font: "Calibri"  
-        )[#authors.name]]]
+        )[#concatenatedAuthors]]]
   }
 
   pagebreak()
@@ -195,7 +199,7 @@
         #text(
           size: 12.5pt,
           font: "Calibri"
-        )[#authors.name]]]
+        )[#concatenatedAuthors]]]
 
     line(
     stroke: 1.5pt + rgb("#C84957"),


### PR DESCRIPTION
I omkodingen av felt fra Quarto til Typst må filbaner bør filbaner omdekkes med anførselstegn, men det gjorde at sjekken om references er none blir feil, da den vil være en tom streng om references ikke oppgis. Ordnet nå.
Closes #2 