### PR TITLE
Type as literal

### DIFF
--- a/_extensions/nifu_pub/typst-show.typ
+++ b/_extensions/nifu_pub/typst-show.typ
@@ -13,6 +13,7 @@
   report_no: "$report_no$",
   project_no: "$project_no$",
   isbn: "$isbn$",
+  isbn_online: "$isbn_online$",
   issn: "$issn$",
   funder: "$funder$",
   funder_address: "$funder_address$",

--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -53,7 +53,7 @@
       }
     ))
     
-  let concatenatedAuthors = if type(authors) != "string" [
+  let concatenatedAuthors = if type(authors) != str [
      #authors.join(", ", last: " og ")
      ] else [#authors]
 

--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -20,6 +20,7 @@
   references: none,
   appendix: none,
   isbn: none,
+  isbn_online: none,
   issn: none,
   date: none,
   signer_1: none,
@@ -269,7 +270,10 @@
     [Fotomontasje], [NIFU],
     [], [],
     [ISBN], [#isbn],
-    [ISSN], [#issn])
+    [ISBN], [#isbn_online],
+    [ISSN], [#issn]
+    )
+  }
   
   image("_images/CC-BY.svg", width: 8em)
   


### PR DESCRIPTION
Var en advarsel med Typst 0.12 at man ikke lenger skal sjekke type ved type(authors) != "string" men != str