### PR TITLE
Set indent to zero cm instead of none, as per Typst warning

### DIFF
--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -318,7 +318,7 @@
       size: 23.5pt
     )[Innhold]],
   depth: 2,
-  indent: none)
+  indent: 0cm)
   
   pagebreak()
   


### PR DESCRIPTION
Closes #48 