### PR TITLE
Explicit lang in template

### DIFF
--- a/_extensions/nifu_pub/typst-show.typ
+++ b/_extensions/nifu_pub/typst-show.typ
@@ -27,5 +27,6 @@
   figure_table: $figure_table$,
   table_table: $table_table$,
   path_cover_upper_image: "$path_cover_upper_image$",
+  lang: "$lang$",
   doc,
 ) 

--- a/_extensions/nifu_pub/typst-template.typ
+++ b/_extensions/nifu_pub/typst-template.typ
@@ -62,7 +62,8 @@
   
   set text(
     font: "Cambria",
-    size: fontsize)
+    size: fontsize,
+    lang: "nb")
   
   show heading.where(level: 1): it => {
     if it.numbering != none {

--- a/eksempel.qmd
+++ b/eksempel.qmd
@@ -30,7 +30,6 @@ format:
   NIFU_pub-typst: default
 keep-typ: true
 references: refs.bib
-lang: nb
 execute: 
   echo: false
 crossref:
@@ -55,7 +54,7 @@ library(tinytable)
 
 # Dette er den aller første overskriften, som nok er litt i lengste laget
 
-Dette blir bra @hjorland.
+Dette blir bra @hjorland. Vi kan samtidig sjekke om anførselstegn "blir riktig".
 
 {{< lipsum 3 >}}
 


### PR DESCRIPTION
Jeg greide ikke helt å la språk bli innstilt fra qmd-filen (fikk ikke til å hente inn variabelen i `#text(lang: lang)` men første steg er på plass og det er nå hardkodet til "nb", så får Jon bare bli sur i fremtiden.

Closes #61 